### PR TITLE
Adding to README and simplifying examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,67 @@
 # NPDemand
 
 [![Build Status](https://travis-ci.com/jamesbrandecon/NPDemand.jl.svg?branch=master)](https://travis-ci.com/jamesbrandecon/NPDemand.jl)
-<!-- 
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/jamesbrandecon/NPDemand.jl?svg=true)](https://ci.appveyor.com/project/jamesbrandecon/NPDemand-jl)
-[![Coverage](https://codecov.io/gh/jamesbrandecon/NPDemand.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/jamesbrandecon/NPDemand.jl)
-[![Coverage](https://coveralls.io/repos/github/jamesbrandecon/NPDemand.jl/badge.svg?branch=master)](https://coveralls.io/github/jamesbrandecon/NPDemand.jl?branch=master) -->
-This package is designed to take data on many markets of potentially many products (where all products are in each market), select small subgroups of products between which substitution is strongest, and estimate structural demand curves nonparametrically on those subgroups. It can currently handle cases in which each subgroup has only 2-4 products, and price is the only observed product characteristic, fairly well. More complicated cases quickly face a curse of dimensionality. See `Initial_Documentation.pdf` for the basics of the package. Documentation based on `Documenter.jl` is in progress. 
 
-Please let me know if you have any suggestions.
+This package is designed to take data on many markets of potentially many products (where all products are in each market), select small subgroups of products between which substitution is strongest, and estimate structural demand curves nonparametrically on those subgroups. It can currently handle cases in which each subgroup has ~8 or fewer products, and price is the only observed product characteristic, fairly well. More complicated cases quickly face a curse of dimensionality.
+
+Please let me know if you have any suggestions for the package.
 
 ## Installation
-The package is extremely new, so it isn't registered. To install, use
+The package is new, so it isn't registered. To install, use
 ```jl
 pkg> add https://github.com/jamesbrandecon/NPDemand.jl
 ```
 
 ## Usage
 There are three important functions included here so far: `inverse_demand`, `price_elasticity`, and `hierNet`/`hierNet_boot`:
-- `inverse_demand(df::DataFrame)`: Takes as input a dataframe with columns s1-sJ, p1-pJ, z1-zJ for J products and estimates inverse demand functions separately for each good. Each inverse demand function is approximated by a Bernstein polynomial of user-chosen order. There are a number of options which are demonstrated in the examples. 
-- `price_elasticity(inv_sigma, df , p_points, included)`: Takes the output of `inverse_demand`, and returns estimates of own- or cross-price elasticities, according to the matrix `included` which specifies which products are substitutes for each other, calculated either at a pre-specified vector of prices `p_points` or at the realized prices in the data. The former requires solving for counterfactual market shares, and is best for getting a sense of the shape of the demand curve. The latter can be used, for example, to calculate markups under traditional models of static pricing in industrial organization.  
-- `hierNet`/`hierNet_boot`: These functions are for model selection. They take as an input a dataframe with columns s1-sJ, p1-pJ, z1-zJ for J products and run constrained lasso regressions (details in draft, coming soon) to select subsets of products which are strong substitutes. `hierNet_boot` runs this procedure multiple times on bootstrapped samples and takes the intersection of selected substitutes across bootstraps. This takes longer but is less likely to include extraneous substitutes. See examples for options. 
+- `inverse_demand(df::DataFrame)`: Takes as input a dataframe with columns `shares0-sharesJ-1`, `prices0 - pricesJ-1`, `demand_instruments0-demand_instrumentsJ-1` for J products and estimates inverse demand functions separately for each good. Each inverse demand function is approximated by a Bernstein polynomial of user-chosen order. There are a number of options which are demonstrated in the examples.
+- `price_elasticity(inv_sigma, df, p_points, included)`: Takes `inv_sigma` (the output of `inverse_demand`), and returns estimates of own- or cross-price elasticities, according to the matrix `included` which specifies which products are substitutes for each other, calculated at a pre-specified vector of prices `p_points`, which can be user-chosen or the realized prices in the data. The former requires solving for counterfactual market shares and setting the option `trueS = false`, and is best for getting a sense of the shape of the demand curve. The latter can be used, for example, to calculate markups under traditional models of static pricing in industrial organization.  
+- `hierNet`/`hierNet_boot`: These functions are for model selection. They take as an input the same DataFrame as above and run constrained lasso regressions (details in draft, coming soon) to select subsets of products which are strong substitutes. `hierNet_boot` runs this procedure multiple times on bootstrapped samples and takes the intersection of selected substitutes across bootstraps. This takes longer but is less likely to include extraneous substitutes. See examples for options.
 
 One helpful additional function is `simulate_logit`, which allows one to easily simulate data from a logit demand system with endogenous prices (and instruments for those prices) to test the `NPDemand` functions.
 
 Rather than run through some short examples here, I've included example files in `/examples` which demonstrates the use of the most important functions and provides descriptions of the relevant inputs.
 
-## Calling from Python/R 
+
+## Model Selection Details
+Model selection follows a modified version of [Bien et al (2013)](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4527358/). Currently, I simply regress each product's `shares`j on all demand instruments. Changing this first-stage to a random forest is on the to-do list for the package. I then run J "hierarchical lasso" regressions of each `prices` on all predicted `shares` with either "weak" or "strong" hierarchy imposed. This regression approximates a product's price with an interacted quadratic function in all market shares.
+
+I then define a product k as being a substitute for j if the linear coefficient on `shares`k is non-zero. When "strong" hierarchy is imposed, this is quite natural, as the quadratic term and any interactions involving `shares`k are nonzero only if the linear term is also nonzero. When "weak" hierarchy is imposed, interaction terms may be nonzero even if the linear term is zero, so this definition of substitutes implicitly treats any such cases as mistaken. Strong hierarchy is therefore better suited to the task at hand, but is far more time consuming and often yields very similar selected models in my simulations.
+
+## Minimal Example with Model Selection
+As described above, begin with a DataFrame which takes the following form:
+```jl
+julia> first(df, 5)
+5×6 DataFrame
+│ Row │ shares0  │ prices0  │ demand_instruments0 │ shares1  │ prices1  │ demand_instruments1 │
+│     │ Float64  │ Float64  │ Float64             │ Float64  │ Float64  │ Float64             │
+├─────┼──────────┼──────────┼─────────────────────┼──────────┼──────────┼─────────────────────┤
+│ 1   │ 0.318976 │ 0.840209 │ 0.377864            │ 0.25169  │ 1.46536  │ 0.612532            │
+│ 2   │ 0.221904 │ 1.41531  │ 0.705143            │ 0.312787 │ 1.88974  │ 0.762217            │
+│ 3   │ 0.252167 │ 1.02818  │ 0.584668            │ 0.252472 │ 2.06294  │ 0.941736            │
+│ 4   │ 0.252374 │ 1.79092  │ 0.788273            │ 0.279031 │ 1.49938  │ 0.672677            │
+│ 5   │ 0.286579 │ 1.28321  │ 0.526458            │ 0.292947 │ 0.459311 │ 0.280061            │
+```
+In this case, there are two goods, so model selection is not necessary, but we can demonstrate the approach regardless. Selecting a model requires a call to `hierNet` or `hierNet_boot`, the latter of which takes an extra option `nboots` which controls the number of bootstrapped samples on which the selection procedure is performed:
+
+```jl
+included, included_symmetric = hierNet_boot(df; nfolds = 5, nlam = 10, strong = false, nboot = 5);
+included, included_symmetric = hierNet(df; nfolds = 5, nlam = 10, strong = false);
+````
+
+The matrix `included` is a matrix of ones and zeros indicating which products are close substitutes, and `included_symmetric` is a similar matrix which enforces that k must substitute for j if j substitutes for k. Next, one can estimate demand and calculate price elasticites:
+
+```jl
+inv_sigma, designs = inverse_demand(df; included = included_symmetric);
+elast, Jacobians, share_vec = price_elasticity(inv_sigma, df, p; whichProducts = [1,1],
+             included = included_symmetric, trueS = true);
+```
+`whichProducts=[j,k]` indicates that you want `elast` to include elasticities of demand for product j with respect to price k, and `trueS = true` indicates that you want these elasticities evaluated at the realized market shares and prices.  
+
+## Calling from Python/R
 Some researchers may wish to call this package directly from Python code. The easiest way to do this is through a Jupyter notebook. In IPython, after running the command `%load_ext julia.magic`, one can call Julia (assuming it is installed) by prefacing each line with `%julia`. In R, one can use the `JuliaCall` package.  
 
 ## To-do
-- Very soon: Permit alternative model selection approaches, e.g. limiting the maximum number of substitutes for each product.
-- Soon: The solver I'm using when demand is constrained to be monotonic is much slower (orders of magnitude) than the CVX solver in Matlab. In search of faster algorithms, and for now monotonicity constraints are not the default. 
-
+- Additional documentation for `hierNet_boot` and `price_elasticity` options.
+- Give option to make first stage prediction in `hierNet` a random forest.
+- Convert Compiani (2020) code to Julia in order to add exchangeability as an optional constraint.

--- a/examples/basic_example.jl
+++ b/examples/basic_example.jl
@@ -19,7 +19,7 @@ elast_cross = zeros(S,G);
 elast_own_dist = zeros(S,T);
 elastTrue = zeros(S,G);
 
-s, p, z, xi = NPDemand.simulate_logit(J,T, beta, sdxi);
+s, p, z, xi = simulate_logit(J,T, beta, sdxi);
 p_points = range(quantile(p[:,1],.25),stop = quantile(p[:,1],.75),length = G);
 p_points = convert.(Float64, p_points)
 
@@ -45,19 +45,19 @@ cross = [1,2];
 # ------------------------------------------------------
 for si = 1:1:S
     # Returns market shares, prices, instruments, and the market demand shock, respectively
-    s, p, z  = NPDemand.simulate_logit(J,T, beta, sdxi);
-    df = NPDemand.toDataFrame(s,p,z);
+    s, p, z  = simulate_logit(J,T, beta, sdxi);
+    df = toDataFrame(s,p,z);
     # Estimate demand nonparametrically
         # If you want to include an additional covariate in all demand
         # functions, add an additional argument "marketvars" after included. If it is an
         # additional product characteristic, marketvars should be T x J
-    inv_sigma, designs = NPDemand.inverse_demand(df; included = included);
+    inv_sigma, designs = inverse_demand(df; included = included);
 
     # Calculate price elasticities
     deltas = -1*median(p).*ones(G,J);
     deltas[:,1] = -1*p_points;
 
-    elast, Jacobians, share_vec = NPDemand.price_elasticity(inv_sigma, df, p_points ; included = included,
+    elast, Jacobians, share_vec = price_elasticity(inv_sigma, df, p_points ; included = included,
         deltas = deltas, whichProducts = own, trueS = false)
 
     trueelast = beta.*p_points.*(1 .-  share_vec[:,1])
@@ -92,10 +92,10 @@ ggplot(df, aes(x=:p, y=:e50)) + geom_line() + geom_line(aes(y=:e975), color = "g
         # Jacobians2 is particularly helpful here. This is an array, each element of which is the Jacobian
         # of demand with respect to prices. This can be used to calculate markups under many models
         # of competition.
-s, p, z  = NPDemand.simulate_logit(J,T, beta, sdxi);
-df = NPDemand.toDataFrame(s,p,z);
-inv_sigma, designs = NPDemand.inverse_demand(df; included = included);
-elast2, Jacobians2 = NPDemand.price_elasticity(inv_sigma, df, p, included = included; deltas = -1 .* p);
+s, p, z  = simulate_logit(J,T, beta, sdxi);
+df = toDataFrame(s,p,z);
+inv_sigma, designs = inverse_demand(df; included = included);
+elast2, Jacobians2 = price_elasticity(inv_sigma, df, p, included = included; deltas = -1 .* p);
 
 df2 = DataFrame(Estimate = elast2, True = beta.*p[:,1].*(1 .- s[:,1]))
 ggplot(df2, aes(x=:True))+

--- a/examples/minimal_example.jl
+++ b/examples/minimal_example.jl
@@ -13,14 +13,14 @@ beta = -0.4; # price coefficient
 sdxi = 0.15; # standard deviation of xi
 
 # Returns market shares, prices, instruments, and the market demand shock, respectively
-s, p, z  = NPDemand.simulate_logit(J,T, beta, sdxi);
-df = NPDemand.toDataFrame(s,p,z);
+s, p, z  = simulate_logit(J, T, beta, sdxi);
+df = toDataFrame(s,p,z);
 
 # Estimate demand nonparametrically
-inv_sigma, designs = NPDemand.inverse_demand(df);
+inv_sigma, designs = inverse_demand(df);
 
 # Calculate price elasticities at realized prices and market shares
-elast, jacobians = NPDemand.price_elasticity(inv_sigma, df, p; deltas = -1 .* p);
+elast, jacobians = price_elasticity(inv_sigma, df, p; deltas = -1 .* p);
 true_elast = beta.*p.*(1 .- s[:,1]) # equation for own-price elasticities in logit model
 
 # Plot kernel densities of estimated and true own-price elasticities

--- a/examples/pure_model_selection.jl
+++ b/examples/pure_model_selection.jl
@@ -30,20 +30,20 @@ included_symmetric_pct = zeros(2J,2J)
 included_pct = zeros(2J,2J)
 for si = 1:1:S
     # Simulate demand in two groups -- each product only substitutes to J-1 others
-    s, pt, zt = NPDemand.simulate_logit(J,T, beta, sdxi);
-    s2, pt2, zt2  = NPDemand.simulate_logit(J,T, beta, sdxi);
+    s, pt, zt = simulate_logit(J,T, beta, sdxi);
+    s2, pt2, zt2  = simulate_logit(J,T, beta, sdxi);
 
     s = [s s2];
     s = s ./ 2;
     pt = [pt pt2];
     zt = [zt zt2];
-    df = NPDemand.toDataFrame(s,pt,zt);
+    df = toDataFrame(s,pt,zt);
 
     # hierNet_boot() Returns two matrices: one, the "raw" selected model, and another
     #   which imposes symmetry. I.e. if j is a substute for k, then k is
     #   a substitute for j as well (this can drastically increase the # parameters
     #    to estimate when s has many columns)
-    included, included_symmetric = NPDemand.hierNet_boot(df; nfolds = nfolds, nlam = nlam, strong = strong, nboot = nboot);
+    included, included_symmetric = hierNet_boot(df; nfolds = nfolds, nlam = nlam, strong = strong, nboot = nboot);
 
     included_pct[:,:] += included./S;
     included_symmetric_pct[:,:] += included_symmetric./S;


### PR DESCRIPTION
Added description of simple example to README.md and modified examples to demonstrate that "NPDemand." prefix is now unnecessary to call NPDemand functions (i.e. now exporting all useful functions)