### PR TITLE
Fixing cross-elasticities + simplifying syntax

### DIFF
--- a/examples/basic_example.jl
+++ b/examples/basic_example.jl
@@ -54,11 +54,11 @@ for si = 1:1:S
     inv_sigma, designs = inverse_demand(df; included = included);
 
     # Calculate price elasticities
-    deltas = -1*median(p).*ones(G,J);
-    deltas[:,1] = -1*p_points;
+    prices = -1*median(p).*ones(G,J);
+    prices[:,1] = -1*p_points;
 
-    elast, Jacobians, share_vec = price_elasticity(inv_sigma, df, p_points ; included = included,
-        deltas = deltas, whichProducts = own, trueS = false)
+    elast, Jacobians, share_vec = price_elasticity(inv_sigma, df, prices; included = included,
+        whichProducts = own, trueS = false)
 
     trueelast = beta.*p_points.*(1 .-  share_vec[:,1])
 

--- a/examples/minimal_example.jl
+++ b/examples/minimal_example.jl
@@ -20,7 +20,7 @@ df = toDataFrame(s,p,z);
 inv_sigma, designs = inverse_demand(df);
 
 # Calculate price elasticities at realized prices and market shares
-elast, jacobians = price_elasticity(inv_sigma, df, p; deltas = -1 .* p);
+elast, jacobians = price_elasticity(inv_sigma, df, p);
 true_elast = beta.*p.*(1 .- s[:,1]) # equation for own-price elasticities in logit model
 
 # Plot kernel densities of estimated and true own-price elasticities

--- a/examples/model_selection_example.jl
+++ b/examples/model_selection_example.jl
@@ -65,11 +65,11 @@ for si = 1:1:S
         # functions, add an additional argument "marketvars" after included. If it is an
         # additional product characteristic, marketvars should be T x J
     inv_sigma, designs = inverse_demand(df; included = included_symmetric);
-    @show size(included_symmetric)
+
     # Calculate price elasticities
-    deltas = -1*median(pt).*ones(G,2J);
-    deltas[:,1] = -1*p_points;
-    elast, Jacobians, share_vec = price_elasticity(inv_sigma, df, p_points; deltas = deltas, whichProducts = own,
+    prices = -1*median(pt).*ones(G,2J);
+    prices[:,1] = -1*p_points;
+    elast, Jacobians, share_vec = price_elasticity(inv_sigma, df, prices; whichProducts = own,
         included = included_symmetric, trueS = trueS);
 
     trueelast = beta.*p_points.*(1 .- 2 .* share_vec[:,1])


### PR DESCRIPTION
The calculation of some own- and cross-price elasticities was incorrect due to a typo. Should be fixed. Also simplified notation/usage a little by automating deltas.